### PR TITLE
README: add sneak.page info

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ We are currently invested in the following technology, but what we offer changes
 Our events will usually be held in German, but we are happy to switch to English!
 
 **You may join our events at: [meet.foremny.me/hannover-functional-programming-meetup](https://meet.foremny.me/hannover-functional-programming-meetup)**
+
+During some of our Meetups we develop a web app called [sneak.page](https://sneak.page/). You may find the [code here](https://github.com/Crazy-Marvin/sneak.page/) and the [mockup here](https://www.figma.com/proto/xa7WL6OE4tMpX2WScvv3zr/Sneak.Page?node-id=19%3A23979&viewport=-699%2C385%2C0.4106914699077606&scaling=min-zoom).


### PR DESCRIPTION
As proposed in today's Meetup I added a line with infos about our project [sneak.page](https://github.com/Crazy-Marvin/sneak.page).