### PR TITLE
chore: externalize projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Our events will usually be held in German, but we are happy to switch to English
 
 **You may join our events at: [meet.foremny.me/hannover-functional-programming-meetup](https://meet.foremny.me/hannover-functional-programming-meetup)**
 
-During some of our Meetups we develop a web app called [sneak.page](https://sneak.page/). You may find the [code here](https://github.com/Crazy-Marvin/sneak.page/) and the [mockup here](https://www.figma.com/proto/xa7WL6OE4tMpX2WScvv3zr/Sneak.Page?node-id=19%3A23979&viewport=-699%2C385%2C0.4106914699077606&scaling=min-zoom).
+**Projects** [Sneak.Page](https://github.com/aforemny/fp-hannover/tree/master/projects)

--- a/projects/README.md
+++ b/projects/README.md
@@ -1,0 +1,9 @@
+# Projects
+
+We are currently working on or have working in the past on the following
+projects:
+
+- [Sneak.Page](https://sneak.page)
+
+  Source code: [github.com/Crazy-Marvin/sneak.page](https://github.com/Crazy-Marvin/sneak.page/)
+  Mockup: [Figma: Sneak.Page](https://www.figma.com/proto/xa7WL6OE4tMpX2WScvv3zr/Sneak.Page?node-id=19%3A23979&viewport=-699%2C385%2C0.4106914699077606&scaling=min-zoom)


### PR DESCRIPTION
As the README.md is currently used as the introduction of the website, I
prefer referencing our projects from there to keep the introduction
short, as the next session should remain close to the top of the page.